### PR TITLE
docs: improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,45 @@
 # ec🌎trajet
 
-<b>ecotrajet</b> est un projet visant à aider les utilisateurs à comparer l'empreinte carbone de différents moyens de transport pour un trajet donné. Conçu pour sensibiliser et encourager des choix plus écoresponsables, il fournit des calculs précis basés sur des données fiables.
+**ecotrajet** est un projet visant à aider les utilisateurs à comparer l'empreinte carbone de différents moyens de transport pour un trajet donné. Conçu pour sensibiliser et encourager des choix plus écoresponsables, il fournit des calculs précis basés sur des données fiables.
 
 Ce projet est construit avec [Next.js](https://nextjs.org) et a été initialisé avec [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app). Le style a été construit avec la librairie [Tailwind](<(https://tailwindcss.com/)>)
 
-<br>
-
 ## 👀 Aperçu
+
 ![website mockup ecotrajet project mandytrl](https://github.com/MandyTrl/ecotrajet/blob/main/public/ecotrajet-mockup.png?raw=true)
 ![pwa darkmonde mockup ecotrajet project mandytrl](https://github.com/MandyTrl/ecotrajet/blob/main/public/ecotrajet-mockup-1.png?raw=true)
-
-<br>
 
 ## 🚀 Installation et exécution
 
 Clonez le dépôt :
-`git clone https://github.com/MandyTrl/ecotrajet.git`
+
+```bash
+git clone https://github.com/MandyTrl/ecotrajet.git
+```
 
 Accédez au répertoire du projet :
-`cd ecotrajet`
+
+```bash
+cd ecotrajet
+```
 
 Installez les dépendances :
 
-```
-npm install
-# ou
+```bash
 yarn install
-# ou
-pnpm install
-# ou
-bun install
 ```
 
 Lancez le serveur de développement :
 
-```
-npm run dev
-# ou
+```bash
 yarn dev
-# ou
-pnpm dev
-# ou
-bun dev
 ```
 
 Ouvrez [http://localhost:3000](http://localhost:3000) dans votre navigateur pour voir l'application.
 
-<br>
-
 ## 🏗️ Structure du projet
 
-```
+```bash
 ├── api
 │   ├── getCity
 │   │   └── route.ts      # route pour le geocoding
@@ -81,17 +70,13 @@ Ouvrez [http://localhost:3000](http://localhost:3000) dans votre navigateur pour
 └── ...                 # autres fichiers
 ```
 
-<br>
-
 ## 🧩 Améliorations prévues
 
-- ~Ajout d'une map pour visualiser les points du trajet.~
-- Ajout d'un tracé sur la map pour visualiser le trajet.
-- ~Ajout de filtres supplémentaires pour le covoiturage par exemple.~
-- ~Comparer l'empreinte carbone du voyage calculé avec le bilan annuel pour obtenir un ratio.~
-- ~Ajout d'un darkmode.~
-
-<br>
+- [ ] Ajout d'une map pour visualiser les points du trajet
+- [ ] Ajout d'un tracé sur la map pour visualiser le trajet
+- [ ] Ajout de filtres supplémentaires pour le covoiturage par exemple
+- [ ] Comparer l'empreinte carbone du voyage calculé avec le bilan annuel pour obtenir un ratio
+- [ ] Ajout d'un dark mode
 
 ## 📂 Sources des données
 
@@ -107,25 +92,28 @@ Les émissions de CO2 sont calculées à partir de données fournies par :
 
 Les contributions sont les bienvenues ! Pour contribuer :
 
-1. Forkez le dépôt.
+1. Forkez le dépôt
 
-2. Créez une nouvelle branche pour votre fonctionnalité ou correction de bug :
+2. Créez une nouvelle branche pour votre fonctionnalité ou correction de bug
 
-`git checkout -b feature/nom-de-la-fonctionnalite`
+```bash
+git checkout -b feature/nom-de-la-fonctionnalite
+```
 
-3. Faites vos modifications et ajoutez un commit :
+3. Faites vos modifications et ajoutez un commit
 
-`git commit -m "Ajout d'une nouvelle fonctionnalité"`
+```bash
+git commit -m "Ajout d'une nouvelle fonctionnalité"
+```
 
-4. Poussez vos modifications sur votre fork :
+4. Poussez vos modifications sur votre fork
 
-`git push origin feature/nom-de-la-fonctionnalite`
+```bash
+git push origin feature/nom-de-la-fonctionnalite
+```
 
 5. Créez une Pull Request vers la branche principale du projet.
 
-<br><br>
+Merci d'utiliser **ecotrajet** ! Si vous avez des suggestions ou des retours, n'hésitez pas à ouvrir une issue ou à me contacter.
 
-Merci d'utiliser <b>ecotrajet</b> ! Si vous avez des suggestions ou des retours, n'hésitez pas à ouvrir une issue ou à me contacter.
-
-<br><br>
-<b>✍️ Mandy Trl - GitHub</b>
+**_✍️ Mandy Trl - GitHub_**


### PR DESCRIPTION
- limit the package manager to `yarn` since there's a `yarn.lock` file
- remove unnecessary line breaks
- use fenced code blocks for better readability